### PR TITLE
Remove header logo and add cosmic background

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,15 +52,8 @@
 
         header .container {
             display: flex;
-            justify-content: space-between;
+            justify-content: flex-end;
             align-items: center;
-        }
-
-        .logo {
-            font-family: 'Orbitron', sans-serif;
-            font-size: 1.5rem;
-            color: var(--primary-color);
-            text-shadow: 0 0 5px var(--primary-color);
         }
 
         .contact-button {
@@ -129,6 +122,20 @@
             /* Glowing text effect */
             text-shadow: 0 0 5px var(--primary-color), 0 0 20px var(--primary-color);
             margin-bottom: 25px;
+            position: relative;
+            z-index: 1;
+        }
+
+        .hero h1::before {
+            content: "宇宙";
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            font-size: 15rem;
+            color: rgba(0, 0, 0, 0.5);
+            z-index: -1;
+            pointer-events: none;
         }
 
         .hero p {
@@ -256,7 +263,6 @@
 <body>
     <header>
         <div class="container">
-            <div class="logo">VEXORIUM TECHNOLOGIES</div>
             <a class="contact-button" href="mailto:Jennifer.Y@Vexorium.net">Contact Us</a>
         </div>
     </header>


### PR DESCRIPTION
## Summary
- Drop redundant header logo so only contact button remains.
- Add subtle dark "宇宙" graphic behind main company name for visual flair.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c647ec957c832da7ee68f70b09cf90